### PR TITLE
Local redis

### DIFF
--- a/ansible/playbooks/kolide-fleet.yml
+++ b/ansible/playbooks/kolide-fleet.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: devsecops_kolide_eip
   become: true
-  gather_facts: false
+  gather_facts: true
   name: Set up Kolide Fleet
   vars_files:
     - ../group_vars/devsecops_kolide_eip/vars.yml
@@ -68,3 +68,5 @@
   - name: Start fleet
     tags: fleet
     command: nohup /usr/local/bin/fleet serve --config /root/.kolide.yml > /var/log/fleet.log 2> /var/log/fleet.err < /dev/null &
+    async: 45
+    poll: 0

--- a/ansible/playbooks/kolide-fleet.yml
+++ b/ansible/playbooks/kolide-fleet.yml
@@ -9,6 +9,7 @@
 
   roles:
     - gsa_kolide_fleet
+    - { role: geerlingguy.redis }
 
   pre_tasks:
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -3,3 +3,5 @@
   name: gsa_ubuntu_16_hardening
 - src: https://github.com/GSA/ansible-role-kolide-fleet
   name: gsa_kolide_fleet
+- src: https://github.com/geerlingguy/ansible-role-redis
+  name: geerlingguy.redis

--- a/terraform/fleet-elasticache.tf
+++ b/terraform/fleet-elasticache.tf
@@ -1,11 +1,11 @@
-module "kolide_redis" {
-  source = "github.com/terraform-community-modules/tf_aws_elasticache_redis?ref=1.0.1"
-  env = "${var.kolide_redis_environment}"
-  name = "${var.kolide_redis_cluster_name}"
-  redis_clusters = "${var.kolide_redis_clusters}"
-  redis_failover = "${var.kolide_redis_failover}"
-  allowed_cidr = "${var.kolide_redis_allowed_cidr}"
-  redis_node_type = "${var.kolide_redis_node_type}"
-  subnets = "${data.terraform_remote_state.infrastructure_remote_state.database_subnet_ids}"
-  vpc_id = "${data.terraform_remote_state.infrastructure_remote_state.vpc_id}"
-}
+# module "kolide_redis" {
+#   source = "github.com/terraform-community-modules/tf_aws_elasticache_redis?ref=1.0.1"
+#   env = "${var.kolide_redis_environment}"
+#   name = "${var.kolide_redis_cluster_name}"
+#   redis_clusters = "${var.kolide_redis_clusters}"
+#   redis_failover = "${var.kolide_redis_failover}"
+#   allowed_cidr = "${var.kolide_redis_allowed_cidr}"
+#   redis_node_type = "${var.kolide_redis_node_type}"
+#   subnets = "${data.terraform_remote_state.infrastructure_remote_state.database_subnet_ids}"
+#   vpc_id = "${data.terraform_remote_state.infrastructure_remote_state.vpc_id}"
+# }

--- a/terraform/kolide-config.tf
+++ b/terraform/kolide-config.tf
@@ -3,7 +3,7 @@ data "template_file" "kolide_vars" {
 
   vars {
     kolide_rds_endpoint = "${module.kolide_rds_database.this_db_instance_endpoint}"
-    kolide_elasticache_endpoint = "${module.kolide_redis.endpoint}"
+    kolide_elasticache_endpoint = "${var.kolide_redis_endpoint}"
     kolide_rds_db_name = "${var.kolide_rds_db_name}"
     kolide_rds_username = "${var.kolide_rds_username}"
     kolide_rds_password = "${var.kolide_rds_password}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,7 +3,7 @@ output "kolide_public_ip" {
 }
 
 output "kolide_elasticache_endpoint" {
-    value = "${module.kolide_redis.endpoint}"
+    value = "${var.kolide_redis_endpoint}"
 }
 
 output "kolide_rds_endpoint" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -275,3 +275,9 @@ variable "kolide_redis_node_type" {
     type = "string"
     default = "cache.m3.medium"
 }
+
+variable "kolide_redis_endpoint" {
+    description = "Endpoint of the redis cluster"
+    type = "string"
+    default = "127.0.0.1"
+}


### PR DESCRIPTION
Switched to local redis since Elasticache seems to have capacity issues. Uses the geerlingguy ansible role to install redis on the local instance. We can stick with this for now, because the AWS capacity issues for elasticache raise an interesting question for our design and for other repos - but we can discuss another day :)